### PR TITLE
Using SemVer lib for version compare

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "axios": "^1.6.3",
         "fs-extra": "^11.2.0",
         "node-cache": "^5.1.2",
-        "path": "^0.12.7"
+        "path": "^0.12.7",
+        "semver": "^7.5.4"
       },
       "devDependencies": {
         "@istanbuljs/nyc-config-typescript": "^1.0.2",
@@ -20,6 +21,7 @@
         "@types/fs-extra": "^11.0.4",
         "@types/mocha": "^10.0.6",
         "@types/node": "^20.10.6",
+        "@types/semver": "^7.5.6",
         "@types/sinon": "^17.0.2",
         "@typescript-eslint/eslint-plugin": "^6.16.0",
         "chai": "^4.3.10",
@@ -3209,7 +3211,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -4330,7 +4331,6 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -4928,8 +4928,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yargs": {
       "version": "16.2.0",
@@ -7314,7 +7313,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -8133,7 +8131,6 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
       }
@@ -8562,8 +8559,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
       "version": "16.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mbelangerb/riotmodule",
-  "version": "2024.1.0",
+  "version": "2024.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mbelangerb/riotmodule",
-      "version": "2024.1.0",
+      "version": "2024.1.1",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.6.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mbelangerb/riotmodule",
-  "version": "2024.1.0",
+  "version": "2024.1.1",
   "description": "Bedy Riot module - Module for call Riot service and obtains information",
   "main": "build/index.js",
   "types": "./build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "axios": "^1.6.3",
     "fs-extra": "^11.2.0",
     "node-cache": "^5.1.2",
-    "path": "^0.12.7"
+    "path": "^0.12.7",
+    "semver": "^7.5.4"
   },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.2",
@@ -57,6 +58,7 @@
     "@types/fs-extra": "^11.0.4",
     "@types/mocha": "^10.0.6",
     "@types/node": "^20.10.6",
+    "@types/semver": "^7.5.6",
     "@types/sinon": "^17.0.2",
     "@typescript-eslint/eslint-plugin": "^6.16.0",
     "chai": "^4.3.10",

--- a/src/declaration/major/EnvVars.ts
+++ b/src/declaration/major/EnvVars.ts
@@ -35,12 +35,12 @@ export default {
             loadingScreenByChampion: 'https://ddragon.leagueoflegends.com/cdn/img/champion/loading/{championName}_{skinId}.jpg',
             splashArtByChampionId: 'https://cdn.communitydragon.org/latest/champion/{championId}/splash-art/centered.jpg',
             skinSplashArtByChampionId: 'https://cdn.communitydragon.org/latest/champion/{championId}/splash-art/centered/skin/{skinId}.jpg',
-            tilesByChampionId: 'https://cdn.communitydragon.org/latest/champion/{championId}/tile.jpg',    
-            skinTilesByChampionId: 'https://cdn.communitydragon.org/latest/champion/{championId}/tile/skin/{skinId}.jpg',         
+            tilesByChampionId: 'https://cdn.communitydragon.org/latest/champion/{championId}/tile.jpg',
+            skinTilesByChampionId: 'https://cdn.communitydragon.org/latest/champion/{championId}/tile/skin/{skinId}.jpg',
         },
         rawUrl: {
-            champion_tiles: 'https://raw.communitydragon.org/latest/plugins/rcp-be-lol-game-data/global/default/v1/champion-tiles/{championId}/{skinId}.jpg'
-        }
+            champion_tiles: 'https://raw.communitydragon.org/latest/plugins/rcp-be-lol-game-data/global/default/v1/champion-tiles/{championId}/{skinId}.jpg',
+        },
     },
     routes: {
         account: {
@@ -51,8 +51,8 @@ export default {
         },
         spectator: {
             v4: {
-                getCurrentGameInfoBySummoner: 'https://{region}.api.riotgames.com/lol/spectator/v4/active-games/by-summoner/{encryptedSummonerId}',    
-            }
+                getCurrentGameInfoBySummoner: 'https://{region}.api.riotgames.com/lol/spectator/v4/active-games/by-summoner/{encryptedSummonerId}',
+            },
         },
         match: {
             v4: {
@@ -60,7 +60,7 @@ export default {
                 getMatchlist: 'https://{region}.api.riotgames.com/lol/match/v4/matchlists/by-account/{encryptedAccountId}?endIndex={end}&beginIndex={begin}',
             },
             v5: {
-            }
+            },
         },
         league: {
             v4: {

--- a/src/entity/Account-v1/AccountDTO.ts
+++ b/src/entity/Account-v1/AccountDTO.ts
@@ -1,6 +1,14 @@
 export interface IAccountDTO {
     puuid: string;
+    /**
+     * MinLength : 3
+     * MaxLength : 16
+     */
     gameName: string;
+    /**
+     * MinLength : 3
+     * MaxLength : 5
+     */
     tagLine: string;
 }
 

--- a/src/service/CacheService.ts
+++ b/src/service/CacheService.ts
@@ -61,7 +61,7 @@ export const CacheName = {
     DRAGON_CHAMPIONS_KEY_NAME: 'dragonChampion_name-{0}',
 
     /**
-    * Params 
+    * Params
     *   {0} = Culture
     *   {1} = Name
     * Contains IDragonChampion

--- a/src/service/DragonService.ts
+++ b/src/service/DragonService.ts
@@ -8,8 +8,6 @@ import { DragonChampion, DragonFile, DragonVersion, IDragonChampion, IDragonVers
 import { ReturnData } from '../declaration/interface/IReturnData';
 import RiotHttpStatusCode from '../declaration/RiotHttpStatusCode';
 import { RequestService } from './RequestService';
-import { castToNumber } from '../declaration/functions';
-// import { compareVersions } from 'compare-versions';
 import { gt } from 'semver';
 
 // **** Variables **** //
@@ -245,9 +243,10 @@ export abstract class DragonService {
         if (downloadResult && downloadResult.code == 200 && downloadResult.data != null && Array.isArray(downloadResult.data)) {
             intData.data!.onlineVersion = downloadResult.data[0].toString();
 
-            const currentVersionStr: string = (intData.data!.internalVersion != null ? intData.data!.internalVersion! : "0.0.0");
-            const onlineVersionStr: string = (intData.data!.onlineVersion != null ? intData.data!.onlineVersion! : "0.0.0");
+            const currentVersionStr: string = (intData.data!.internalVersion != null ? intData.data!.internalVersion! : '0.0.0');
+            const onlineVersionStr: string = (intData.data!.onlineVersion != null ? intData.data!.onlineVersion! : '0.0.0');
 
+            /* istanbul ignore else */
             if (gt(onlineVersionStr, currentVersionStr)) {
                 intData.data!.requiredUpdate = true;
             }
@@ -347,7 +346,7 @@ export abstract class DragonService {
 
     // #endregion
 
-    //#region "Read Dragon file"
+    // #region "Read Dragon file"
     /**
      * Read dragon champion details file. The detail file content all information for a specific champion.
      * @param championName League of Legend champion name
@@ -393,8 +392,8 @@ export abstract class DragonService {
                         name: dragonChampionInfo.name,
                         title: dragonChampionInfo.title,
                         image: dragonChampionInfo.image,
-                        skins: dragonChampionInfo.skins
-                    }
+                        skins: dragonChampionInfo.skins,
+                    };
                 }
             }
 
@@ -538,7 +537,7 @@ export abstract class DragonService {
 
         return championData;
     }
-    //#endregion
+    // #endregion
 
     // #region "Download/Write dragon file"
 
@@ -559,11 +558,11 @@ export abstract class DragonService {
 
     /**
      * Download a specific dragon champion file and write the file in server
-     * @param championName 
-     * @param dragonCulture 
-     * @returns 
+     * @param championName
+     * @param dragonCulture
+     * @returns
      */
-    private static async downloadAndReadDetailedChampionFile<T>(championName: string, dragonCulture: DragonCulture): Promise<ReturnData<DragonFile<DragonChampion[]>>> {
+    private static async downloadAndReadDetailedChampionFile(championName: string, dragonCulture: DragonCulture): Promise<ReturnData<DragonFile<DragonChampion[]>>> {
         // console.log('Enter in DragonService.downloadAndReadDetailedChampionFile');
 
         // We check the version
@@ -606,7 +605,7 @@ export abstract class DragonService {
 
         // ---------------------
         // Prepare return data
-        let returnData: ReturnData<DragonFile<T>> = new ReturnData<DragonFile<T>>;
+        const returnData: ReturnData<DragonFile<T>> = new ReturnData<DragonFile<T>>;
         let tmpData: DragonFile<T> = new DragonFile<T>();
 
         /* istanbul ignore else */
@@ -614,8 +613,10 @@ export abstract class DragonService {
             tmpData = FileService.readInternalJSONFile(dragonFilePath);
 
             // Check if current dragon file required a update
-            const currentDragonFileVersionStr: string = (tmpData.version != null ? tmpData.version! : "0.0.0");
-            const currentOnlineVersionStr: string = (versionData.data!.onlineVersion != null ? versionData.data!.onlineVersion! : "0.0.0");
+            const currentDragonFileVersionStr: string = (tmpData.version != null ? tmpData.version! : '0.0.0');
+            const currentOnlineVersionStr: string = (versionData.data!.onlineVersion != null ? versionData.data!.onlineVersion! : '0.0.0');
+
+            /* istanbul ignore else */
             if (gt(currentOnlineVersionStr, currentDragonFileVersionStr)) {
                 versionData.data!.requiredUpdate = true;
             }

--- a/src/service/FileService.ts
+++ b/src/service/FileService.ts
@@ -131,10 +131,11 @@ export abstract class FileService {
 
     /**
      * Read the content on a static file (if file exists)
-     * @param filePath {string} 
+     * @param filePath {string}
      * @returns {any | undefined}
      */
-    static readStaticFileContent<T>(filePath: string) : any | undefined {
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    static readStaticFileContent(filePath: string) : any | undefined {
         /* istanbul ignore else */
         if (FileService.checkFileExists(filePath)) {
             // If version file already exists we read the file

--- a/test/services/dragon.spec.ts
+++ b/test/services/dragon.spec.ts
@@ -204,8 +204,9 @@ describe('===> Test DragonService', () => {
 
     assert.isNotNull(result.data);
     assert.isNotNull(result.data?.internalVersion);
-    assert.notEqual(result.data?.internalVersion, "0");
-  }); // .timeout(10000);
+    assert.isDefined(result.data?.internalVersion);
+    assert.notEqual(result.data?.internalVersion, "0.0.0");
+  }).timeout(5000);
 
   it('2.2.1 => Update version list (Dragon)', async () => {
     // Because cache is enabled, we need to clean the cache created  by lastest tests
@@ -238,8 +239,7 @@ describe('===> Test DragonService', () => {
       assert.fail('BaseFile doesn\'t exists')
     }
   }); // .timeout(10000);
-
-  
+ 
   it('3.0.0 => Get summary champion info in file by championId', async () => {
     const championInfo: DragonChampion = await DragonService.getChampionInfoById(99, DragonCulture.fr_fr);
 


### PR DESCRIPTION
Rework on the manual dragon version compare. We now using "semver" lib.

The process of manually converting the string into numbers could create a problem.

Good answer was TRUE, but the convert return FALSE
```
const currentVersion = "13.10.1"; // Str : 13101
const newVersion = "14.1.1"; // Str : 1411

//  13101 < 1411 => False.
```